### PR TITLE
Supporting partial schema resolution using import schemaLocation hint path

### DIFF
--- a/src/Schematron.Tests/Content/po-instance.xml
+++ b/src/Schematron.Tests/Content/po-instance.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<orders xmlns="http://example.com/po-schematron">
+  <customer sex="Female" title="Mr" customerId="q3qw" partnerId="asdfasd">
+    <firstName>Daniel</firstName>
+    <lastName>Cazzulino</lastName>
+		<p></p>
+    <order orderDate="2002-10-20" orderStatus="Cancelled">
+      <paymentInfo date="2002-10-21" method="Card">
+        <cardDetails>
+          <!-- credit card info -->
+        </cardDetails>
+      </paymentInfo>
+
+      <items>
+        <item partNum="872-AA">
+          <productName>Lawnmower</productName>
+          <!--<quantity>1</quantity>-->
+          <USPrice>148.95</USPrice>
+          <rebate amount="15" code="BSD890" />
+        </item>
+
+        <item partNum="926-AA">
+          <productName>Baby Monitor</productName>
+          <quantity>1</quantity>
+          <USPrice>39.98</USPrice>
+          <shipDate>2002-05-21</shipDate>
+          <rebate amount="10" code="PJS572" />
+        </item>
+
+        <item partNum="911-AA">
+          <productName>Alerter Phone</productName>
+          <quantity>2</quantity>
+          <USPrice>70.43</USPrice>
+          <shipDate>2002-05-21</shipDate>
+        </item>
+      </items>
+    </order>
+
+    <order orderDate="2002-10-20" orderStatus="Cancelled">
+      <cancelInfo reason="TiredOfWaiting">
+        <userMessage>
+          Couldn't get this order on time 
+          and now it's useless!
+        </userMessage>
+      </cancelInfo>
+    </order>
+    
+  </customer>
+</orders>

--- a/src/Schematron.Tests/Content/po-schema-with-schema-import.xsd
+++ b/src/Schematron.Tests/Content/po-schema-with-schema-import.xsd
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  targetNamespace="http://example.com/po-schematron" 
+  xmlns="http://example.com/po-schematron"
+  xmlns:status="http://example.com/po-schematron/status"
+  elementFormDefault="qualified" 
+  attributeFormDefault="unqualified">
+
+  <xsd:import namespace="http://example.com/po-schematron/status" schemaLocation="statusDef.xsd"></xsd:import>
+  
+    <xsd:annotation>
+        <xsd:appinfo>
+            <schema xmlns="http://www.ascc.net/xml/schematron">
+                <title>Purchase Orders</title>
+                <ns uri="http://example.com/po-schematron" prefix="po" />
+
+                <pattern name="Basic data">
+                    <rule context="po:customer">
+                        <assert test="(@sex='Male' and @title='Mr') or (@sex='Female' and (@title='Mrs' or @title='Miss'))">
+													Attributes sex and title must have compatible values on element <name/>.
+												</assert>
+                        <report test="@customerId and @partnerId">
+													Both customerId and partnerId can't be present on element <name/>.
+												</report>
+                        <report test="not(@customerId) and not(@partnerId)">
+													Either customerId or partnerId must be present on element <name/>.
+												</report>
+                    </rule>
+                </pattern>
+            </schema>
+        </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:element name="orders">
+        <xsd:annotation>
+            <xsd:appinfo>
+                <!-- General order-related constraints -->
+                <pattern name="Exceptional Orders" xmlns="http://www.ascc.net/xml/schematron">
+                    <rule context="po:order[count(po:items/po:item) > 100]">
+                        <assert test="@priority = 'Max'">
+													An <name /> with more than a hundred items must have a maximum priority (@priotity=‘Max’).
+												</assert>
+                        <report test="not(../@partnerId)">
+													Only partners can place this type of order.
+												</report>
+                    </rule>
+                </pattern>
+                <pattern name="Special Offers" xmlns="http://www.ascc.net/xml/schematron">
+                    <rule context="po:order">
+                        <assert test="count(po:items/po:item/po:rebate) &lt;= 2">
+													Up to two special rebates are allowed for each purchase order.
+												</assert>
+                        <assert test="sum(po:items/po:item/po:rebate/@amount) &lt;= 30">
+													The total discounted percentage can't be greater than 30%.
+												</assert>
+                    </rule>
+                </pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="customer" minOccurs="1" maxOccurs="unbounded">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element name="firstName" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                            <xsd:element name="lastName" type="xsd:string" minOccurs="1" maxOccurs="1" />
+                            <xsd:element name="order" type="orderDef" minOccurs="0" maxOccurs="unbounded" />
+                        </xsd:sequence>
+                        <xsd:attribute name="title" type="titleDef" />
+                        <xsd:attribute name="sex" type="sexDef" />
+                        <xsd:attribute name="customerId" type="xsd:string" />
+                        <xsd:attribute name="partnerId" type="xsd:string" />
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    <!-- Becomes required depending on content -->
+    <xsd:simpleType name="priorityDef">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Max" />
+            <xsd:enumeration value="Avg" />
+            <xsd:enumeration value="Min" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <!-- Sex and Title have mutual value dependencies -->
+    <xsd:simpleType name="titleDef">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Mr" />
+            <xsd:enumeration value="Mrs" />
+            <xsd:enumeration value="Miss" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="sexDef">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Male" />
+            <xsd:enumeration value="Female" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:complexType name="orderDef">
+        <xsd:sequence>
+            <xsd:element name="paymentInfo" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <!-- Paid orders information -->
+                        <pattern name="Paid orders" id="paymentInfo" xmlns="http://www.ascc.net/xml/schematron">
+                            <rule context="po:order[@orderStatus='Paid']">
+                                <assert test="po:paymentInfo">
+																	Paid orders must include the payment information.
+																</assert>
+                                <report test="po:cancelInfo">
+																	Cancelacion information can't be included for paid <name />.
+																</report>
+                            </rule>
+                            <rule context="po:order[@orderStatus='Paid']/po:paymentInfo">
+                                <report test="@method='Card' and not(po:cardDetails)">
+																	If payment method is "Card", corresponding details must be given in a cardDetails element.
+																</report>
+                                <report test="@method='Cheque' and not(po:chequeDetails)">
+																	If payment method is "Cheque", corresponding details must be given in a chequeDetails element.
+																</report>
+                                <report test="@method='Cash' and (po:cardDetails or po:chequeDetails)">
+																	If payment method is "Cash", cardDetails or chequeDetails aren't applicable.
+																</report>
+                            </rule>
+                        </pattern>
+                    </xsd:appinfo>
+                </xsd:annotation>
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="cardDetails" type="xsd:string" minOccurs="0" />
+                        <xsd:element name="chequeDetails" type="xsd:string" minOccurs="0" />
+                    </xsd:sequence>
+                    <xsd:attribute name="method">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:enumeration value="Cash" />
+                                <xsd:enumeration value="Cheque" />
+                                <xsd:enumeration value="Card" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:attribute>
+                    <xsd:attribute name="date" type="xsd:date" />
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="cancelInfo" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <!-- Paid orders information -->
+                        <pattern name="Paid orders" id="cancelInfo" xmlns="http://www.ascc.net/xml/schematron">
+                            <rule context="po:order[@orderStatus='Cancelled']">
+                                <assert test="po:cancelInfo">
+																	Canceled orders must include the cancel information.
+																</assert>
+                                <report test="po:paymentInfo">
+																	Payment information can't be included for canceled <name />.
+																</report>
+                            </rule>
+                        </pattern>
+                    </xsd:appinfo>
+                </xsd:annotation>
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="userMessage" type="xsd:string" />
+                    </xsd:sequence>
+                    <xsd:attribute name="reason">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:enumeration value="FailedDelivery" />
+                                <xsd:enumeration value="PriceTooHigh" />
+                                <xsd:enumeration value="PaymentNotAvailable" />
+                                <xsd:enumeration value="TiredOfWaiting" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:attribute>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="items" type="Items" minOccurs="0" />
+            <xsd:element name="shipTo" type="USAddressDef" minOccurs="0" />
+            <xsd:element name="billTo" type="USAddressDef" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="orderDate" type="xsd:date" />
+        <xsd:attribute name="orderStatus" type="status:statusDef" use="required" />
+        <xsd:attribute name="priority" type="priorityDef" default="Avg" />
+    </xsd:complexType>
+    <xsd:complexType name="USAddressDef">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" />
+            <xsd:element name="street" type="xsd:string" />
+            <xsd:element name="city" type="xsd:string" />
+            <xsd:element name="state" type="xsd:string" />
+            <xsd:element name="zip" type="xsd:decimal" />
+        </xsd:sequence>
+        <xsd:attribute name="country" type="xsd:NMTOKEN" fixed="US" />
+    </xsd:complexType>
+    <xsd:complexType name="Items">
+        <xsd:sequence>
+            <xsd:element name="item" minOccurs="0" maxOccurs="unbounded">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="productName" type="xsd:string" />
+                        <xsd:element name="quantity">
+                            <xsd:simpleType>
+                                <xsd:restriction base="xsd:positiveInteger">
+                                    <xsd:maxExclusive value="100" />
+                                </xsd:restriction>
+                            </xsd:simpleType>
+                        </xsd:element>
+                        <xsd:element name="USPrice" type="xsd:decimal" />
+                        <xsd:element name="shipDate" type="xsd:date" minOccurs="0" />
+                        <!-- Occurrence restrictions don't satisfy business requirement -->
+                        <xsd:element name="rebate" minOccurs="0" maxOccurs="1">
+                            <xsd:complexType>
+                                <xsd:attribute name="code" type="xsd:string" />
+                                <xsd:attribute name="amount" type="xsd:string" />
+                            </xsd:complexType>
+                        </xsd:element>
+                    </xsd:sequence>
+                    <xsd:attribute name="partNum" type="SKU" use="required" />
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- Stock Keeping Unit, a code for identifying products -->
+    <xsd:simpleType name="SKU">
+        <xsd:restriction base="xsd:string">
+            <xsd:pattern value="\d{3}-[A-Z]{2}" />
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>

--- a/src/Schematron.Tests/Content/po-schema.xsd
+++ b/src/Schematron.Tests/Content/po-schema.xsd
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://example.com/po-schematron" xmlns="http://example.com/po-schematron" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xsd:annotation>
+        <xsd:appinfo>
+            <schema xmlns="http://www.ascc.net/xml/schematron">
+                <title>Purchase Orders</title>
+                <ns uri="http://example.com/po-schematron" prefix="po" />
+
+                <pattern name="Basic data">
+                    <rule context="po:customer">
+                        <assert test="(@sex='Male' and @title='Mr') or (@sex='Female' and (@title='Mrs' or @title='Miss'))">
+													Attributes sex and title must have compatible values on element <name/>.
+												</assert>
+                        <report test="@customerId and @partnerId">
+													Both customerId and partnerId can't be present on element <name/>.
+												</report>
+                        <report test="not(@customerId) and not(@partnerId)">
+													Either customerId or partnerId must be present on element <name/>.
+												</report>
+                    </rule>
+                </pattern>
+            </schema>
+        </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:element name="orders">
+        <xsd:annotation>
+            <xsd:appinfo>
+                <!-- General order-related constraints -->
+                <pattern name="Exceptional Orders" xmlns="http://www.ascc.net/xml/schematron">
+                    <rule context="po:order[count(po:items/po:item) > 100]">
+                        <assert test="@priority = 'Max'">
+													An <name /> with more than a hundred items must have a maximum priority (@priotity=‘Max’).
+												</assert>
+                        <report test="not(../@partnerId)">
+													Only partners can place this type of order.
+												</report>
+                    </rule>
+                </pattern>
+                <pattern name="Special Offers" xmlns="http://www.ascc.net/xml/schematron">
+                    <rule context="po:order">
+                        <assert test="count(po:items/po:item/po:rebate) &lt;= 2">
+													Up to two special rebates are allowed for each purchase order.
+												</assert>
+                        <assert test="sum(po:items/po:item/po:rebate/@amount) &lt;= 30">
+													The total discounted percentage can't be greater than 30%.
+												</assert>
+                    </rule>
+                </pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="customer" minOccurs="1" maxOccurs="unbounded">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element name="firstName" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                            <xsd:element name="lastName" type="xsd:string" minOccurs="1" maxOccurs="1" />
+                            <xsd:element name="order" type="orderDef" minOccurs="0" maxOccurs="unbounded" />
+                        </xsd:sequence>
+                        <xsd:attribute name="title" type="titleDef" />
+                        <xsd:attribute name="sex" type="sexDef" />
+                        <xsd:attribute name="customerId" type="xsd:string" />
+                        <xsd:attribute name="partnerId" type="xsd:string" />
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    <!-- Becomes required depending on content -->
+    <xsd:simpleType name="priorityDef">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Max" />
+            <xsd:enumeration value="Avg" />
+            <xsd:enumeration value="Min" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <!-- Sex and Title have mutual value dependencies -->
+    <xsd:simpleType name="titleDef">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Mr" />
+            <xsd:enumeration value="Mrs" />
+            <xsd:enumeration value="Miss" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="sexDef">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Male" />
+            <xsd:enumeration value="Female" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="statusDef">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Cancelled" />
+            <xsd:enumeration value="Paid" />
+            <xsd:enumeration value="Placed" />
+            <xsd:enumeration value="Submitted" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:complexType name="orderDef">
+        <xsd:sequence>
+            <xsd:element name="paymentInfo" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <!-- Paid orders information -->
+                        <pattern name="Paid orders" id="paymentInfo" xmlns="http://www.ascc.net/xml/schematron">
+                            <rule context="po:order[@orderStatus='Paid']">
+                                <assert test="po:paymentInfo">
+																	Paid orders must include the payment information.
+																</assert>
+                                <report test="po:cancelInfo">
+																	Cancelacion information can't be included for paid <name />.
+																</report>
+                            </rule>
+                            <rule context="po:order[@orderStatus='Paid']/po:paymentInfo">
+                                <report test="@method='Card' and not(po:cardDetails)">
+																	If payment method is "Card", corresponding details must be given in a cardDetails element.
+																</report>
+                                <report test="@method='Cheque' and not(po:chequeDetails)">
+																	If payment method is "Cheque", corresponding details must be given in a chequeDetails element.
+																</report>
+                                <report test="@method='Cash' and (po:cardDetails or po:chequeDetails)">
+																	If payment method is "Cash", cardDetails or chequeDetails aren't applicable.
+																</report>
+                            </rule>
+                        </pattern>
+                    </xsd:appinfo>
+                </xsd:annotation>
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="cardDetails" type="xsd:string" minOccurs="0" />
+                        <xsd:element name="chequeDetails" type="xsd:string" minOccurs="0" />
+                    </xsd:sequence>
+                    <xsd:attribute name="method">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:enumeration value="Cash" />
+                                <xsd:enumeration value="Cheque" />
+                                <xsd:enumeration value="Card" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:attribute>
+                    <xsd:attribute name="date" type="xsd:date" />
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="cancelInfo" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <!-- Paid orders information -->
+                        <pattern name="Paid orders" id="cancelInfo" xmlns="http://www.ascc.net/xml/schematron">
+                            <rule context="po:order[@orderStatus='Cancelled']">
+                                <assert test="po:cancelInfo">
+																	Canceled orders must include the cancel information.
+																</assert>
+                                <report test="po:paymentInfo">
+																	Payment information can't be included for canceled <name />.
+																</report>
+                            </rule>
+                        </pattern>
+                    </xsd:appinfo>
+                </xsd:annotation>
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="userMessage" type="xsd:string" />
+                    </xsd:sequence>
+                    <xsd:attribute name="reason">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:enumeration value="FailedDelivery" />
+                                <xsd:enumeration value="PriceTooHigh" />
+                                <xsd:enumeration value="PaymentNotAvailable" />
+                                <xsd:enumeration value="TiredOfWaiting" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:attribute>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="items" type="Items" minOccurs="0" />
+            <xsd:element name="shipTo" type="USAddressDef" minOccurs="0" />
+            <xsd:element name="billTo" type="USAddressDef" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="orderDate" type="xsd:date" />
+        <xsd:attribute name="orderStatus" type="statusDef" use="required" />
+        <xsd:attribute name="priority" type="priorityDef" default="Avg" />
+    </xsd:complexType>
+    <xsd:complexType name="USAddressDef">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" />
+            <xsd:element name="street" type="xsd:string" />
+            <xsd:element name="city" type="xsd:string" />
+            <xsd:element name="state" type="xsd:string" />
+            <xsd:element name="zip" type="xsd:decimal" />
+        </xsd:sequence>
+        <xsd:attribute name="country" type="xsd:NMTOKEN" fixed="US" />
+    </xsd:complexType>
+    <xsd:complexType name="Items">
+        <xsd:sequence>
+            <xsd:element name="item" minOccurs="0" maxOccurs="unbounded">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="productName" type="xsd:string" />
+                        <xsd:element name="quantity">
+                            <xsd:simpleType>
+                                <xsd:restriction base="xsd:positiveInteger">
+                                    <xsd:maxExclusive value="100" />
+                                </xsd:restriction>
+                            </xsd:simpleType>
+                        </xsd:element>
+                        <xsd:element name="USPrice" type="xsd:decimal" />
+                        <xsd:element name="shipDate" type="xsd:date" minOccurs="0" />
+                        <!-- Occurrence restrictions don't satisfy business requirement -->
+                        <xsd:element name="rebate" minOccurs="0" maxOccurs="1">
+                            <xsd:complexType>
+                                <xsd:attribute name="code" type="xsd:string" />
+                                <xsd:attribute name="amount" type="xsd:string" />
+                            </xsd:complexType>
+                        </xsd:element>
+                    </xsd:sequence>
+                    <xsd:attribute name="partNum" type="SKU" use="required" />
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- Stock Keeping Unit, a code for identifying products -->
+    <xsd:simpleType name="SKU">
+        <xsd:restriction base="xsd:string">
+            <xsd:pattern value="\d{3}-[A-Z]{2}" />
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>

--- a/src/Schematron.Tests/Content/statusDef.xsd
+++ b/src/Schematron.Tests/Content/statusDef.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+            targetNamespace="http://example.com/po-schematron/status" 
+            xmlns="http://example.com/po-schematron/status">
+  <xsd:simpleType name="statusDef">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="Cancelled" />
+      <xsd:enumeration value="Paid" />
+      <xsd:enumeration value="Placed" />
+      <xsd:enumeration value="Submitted" />
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/src/Schematron.Tests/Properties/AssemblyInfo.cs
+++ b/src/Schematron.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Schematron.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("Schematron.Tests")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("99fbcd32-47d4-48a8-8e36-52538d45d46a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Schematron.Tests/Properties/AssemblyInfo.cs
+++ b/src/Schematron.Tests/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("99fbcd32-47d4-48a8-8e36-52538d45d46a")]
+[assembly: Guid("bd9d55cc-716c-4e68-86ab-89fd4be643b5")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/src/Schematron.Tests/Schematron.Tests.csproj
+++ b/src/Schematron.Tests/Schematron.Tests.csproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{752937D5-AB1C-48E5-BF00-98AD6D4C728B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Schematron.Tests</RootNamespace>
+    <AssemblyName>Schematron.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.XML" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ValidatorTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Content\po-schema.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Content\po-instance.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Schematron\Schematron.csproj">
+      <Project>{db7369f1-69cf-4821-98e3-9d6422a7cc36}</Project>
+      <Name>Schematron</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Schematron.Tests/Schematron.Tests.csproj
+++ b/src/Schematron.Tests/Schematron.Tests.csproj
@@ -1,21 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{752937D5-AB1C-48E5-BF00-98AD6D4C728B}</ProjectGuid>
+    <ProjectGuid>{0CE72032-070F-479E-8ADD-4C04AE53C1B6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Schematron.Tests</RootNamespace>
     <AssemblyName>Schematron.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,29 +33,32 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
   <ItemGroup>
-    <Compile Include="ValidatorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Content\po-schema.xsd">
-      <SubType>Designer</SubType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Compile Include="ValidatorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Content\po-instance.xml">
@@ -66,31 +66,34 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Content\po-schema-with-schema-import.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Content\po-schema.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Content\statusDef.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Schematron\Schematron.csproj">
       <Project>{db7369f1-69cf-4821-98e3-9d6422a7cc36}</Project>
       <Name>Schematron</Name>
     </ProjectReference>
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Schematron.Tests/ValidatorTests.cs
+++ b/src/Schematron.Tests/ValidatorTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Xml;
+using System.Xml.XPath;
+using System.Xml.Serialization;
+using UnitTesting = Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text;
+
+namespace Schematron.Tests
+{
+    [TestClass]
+    public class ValidatorTests
+    {
+        const string XsdLocation = "./Content/po-schema.xsd";
+        const string XmlContentLocation = "./Content/po-instance.xml";
+        const string TargetNamespace = "http://example.com/po-schematron";
+
+        public ValidatorTests()
+        {
+
+        }
+
+        [ExpectedException(typeof(Schematron.ValidationException))]
+        [TestMethod]
+        public void NewAddSchemaSignatureShouldNotBreakCode()
+        {
+            var validatorA = new Validator(OutputFormatting.XML);
+            validatorA.AddSchema(XmlReader.Create(XsdLocation));
+
+            var validatorB = new Validator(OutputFormatting.XML);
+            validatorB.AddSchema(TargetNamespace, XsdLocation);
+
+            var resultA = default(string);
+            var resultB = default(string);
+
+            try
+            {
+                var result = validatorA.Validate(XmlReader.Create(XmlContentLocation));
+            }
+            catch (ValidationException ex)
+            {
+                resultA = ex.Message;
+
+                System.Diagnostics.Debug.WriteLine(ex.Message);                
+            }
+
+            try
+            {
+                var result = validatorB.Validate(XmlReader.Create(XmlContentLocation));
+            }
+            catch (ValidationException ex)
+            {
+                resultB = ex.Message;
+
+                UnitTesting.Assert.IsTrue(resultA == resultB);
+
+                System.Diagnostics.Debug.WriteLine(ex.Message);
+
+                throw;
+            }
+
+        }
+
+        [TestMethod]
+        public void ValidateShouldReturnSchematronValidationResultWhenSchematronConstraintsAreNotMet()
+        {
+            //Arrange
+            var validator = new Validator(OutputFormatting.XML);
+
+            //Act
+            validator.AddSchema(TargetNamespace, XsdLocation);
+
+            using (var doc = XmlReader.Create(XmlContentLocation))
+            {
+                var result = default(IXPathNavigable);
+
+                try
+                {
+                    result = validator.Validate(doc);
+                }
+                catch (ValidationException ex)
+                {
+                    System.Diagnostics.Debug.WriteLine(ex.Message);
+
+                    var serializer = new XmlSerializer(typeof(Schematron.Serialization.SchematronValidationResultTempObjectModel.output));
+
+                    using (var stream = new MemoryStream(System.Text.Encoding.Unicode.GetBytes(ex.Message)))
+                    using (var reader = XmlReader.Create(stream))
+                    {
+                        var obj = (Schematron.Serialization.SchematronValidationResultTempObjectModel.output)serializer.Deserialize(reader);
+
+                        // Assert
+
+                        UnitTesting.Assert.IsNotNull(obj);
+                        UnitTesting.Assert.IsNotNull(obj.xml);
+                        UnitTesting.Assert.IsNotNull(obj.schematron);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Schematron.Tests/packages.config
+++ b/src/Schematron.Tests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/src/Schematron.sln
+++ b/src/Schematron.sln
@@ -19,7 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{494E6692
 		..\VERSION = ..\VERSION
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Schematron.Tests", "Schematron.Tests\Schematron.Tests.csproj", "{752937D5-AB1C-48E5-BF00-98AD6D4C728B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Schematron.Tests", "Schematron.Tests\Schematron.Tests.csproj", "{0CE72032-070F-479E-8ADD-4C04AE53C1B6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,10 +35,10 @@ Global
 		{D55599AF-DA8B-4FFE-8F99-C2A2DCEE45EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D55599AF-DA8B-4FFE-8F99-C2A2DCEE45EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D55599AF-DA8B-4FFE-8F99-C2A2DCEE45EC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{752937D5-AB1C-48E5-BF00-98AD6D4C728B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{752937D5-AB1C-48E5-BF00-98AD6D4C728B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{752937D5-AB1C-48E5-BF00-98AD6D4C728B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{752937D5-AB1C-48E5-BF00-98AD6D4C728B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CE72032-070F-479E-8ADD-4C04AE53C1B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CE72032-070F-479E-8ADD-4C04AE53C1B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CE72032-070F-479E-8ADD-4C04AE53C1B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CE72032-070F-479E-8ADD-4C04AE53C1B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Schematron.sln
+++ b/src/Schematron.sln
@@ -1,7 +1,5 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Schematron", "Schematron\Schematron.csproj", "{DB7369F1-69CF-4821-98E3-9D6422A7CC36}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "doc", "doc", "{CEE7139C-CEDE-4967-825B-CC6DC0188685}"
@@ -21,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{494E6692
 		..\VERSION = ..\VERSION
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Schematron.Tests", "Schematron.Tests\Schematron.Tests.csproj", "{752937D5-AB1C-48E5-BF00-98AD6D4C728B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +35,10 @@ Global
 		{D55599AF-DA8B-4FFE-8F99-C2A2DCEE45EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D55599AF-DA8B-4FFE-8F99-C2A2DCEE45EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D55599AF-DA8B-4FFE-8F99-C2A2DCEE45EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{752937D5-AB1C-48E5-BF00-98AD6D4C728B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{752937D5-AB1C-48E5-BF00-98AD6D4C728B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{752937D5-AB1C-48E5-BF00-98AD6D4C728B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{752937D5-AB1C-48E5-BF00-98AD6D4C728B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Schematron/Validator.cs
+++ b/src/Schematron/Validator.cs
@@ -337,7 +337,7 @@ namespace Schematron
 
                     if (_haserrors) throw new BadSchemaException(_errors.ToString());
 
-                    set.Add(xs);
+                    schemaSet.Add(xs);
                 }
             }
 
@@ -362,6 +362,8 @@ namespace Schematron
             var xmlContent = default(string);
             var nameTable = default(XmlNameTable);
             var namespaceUri = default(string);
+
+            _xmlschemas = _xmlschemas ?? new XmlSchemaSet();
 
             TryAddXmlSchema(targetNamespace, schemaUri, _xmlschemas, OnValidation, out xmlContent, out nameTable, out namespaceUri);
 

--- a/src/Schematron/Validator.cs
+++ b/src/Schematron/Validator.cs
@@ -287,6 +287,108 @@ namespace Schematron
 			_schematrons.Add(sch);
 			_errors = null;
 		}
+
+
+        #region WORK IN PROGRESS :: The need the for the signature AddSchema(string targetNamespace, string schemaUri) comes from resolving imported (schemaLocation hinted) partial schemas
+
+        private bool TryAddXmlSchema(
+            string targetNamespace,
+            string schemaUri,
+            XmlSchemaSet schemaSet,
+            Action<object, ValidationEventArgs> validationHandler,
+            out string xmlContent,
+            out XmlNameTable nameTable,
+            out string namespaceUri)
+        {
+            xmlContent = default(string);
+            nameTable = default(XmlNameTable);
+            namespaceUri = default(string);
+
+            using (var reader = XmlReader.Create(schemaUri))
+            {
+                if (reader.MoveToContent() == XmlNodeType.None)
+                {
+                    throw new BadSchemaException("No information found to read");
+                }
+
+                nameTable = reader.NameTable;
+                namespaceUri = reader.NamespaceURI;
+                xmlContent = reader.ReadOuterXml();
+
+                if (!IsStandardSchema(namespaceUri))
+                    return false;
+
+                using (var stringReader = new StringReader(xmlContent))
+                {
+                    if (_errors == null)
+                    {
+                        _errors = new StringBuilder();
+                    }
+
+                    var xs = XmlSchema.Read(new XmlTextReader(stringReader, nameTable), new ValidationEventHandler(validationHandler));
+
+                    var set = new XmlSchemaSet();
+                    set.Add(targetNamespace, schemaUri);
+
+                    if (!set.IsCompiled)
+                    {
+                        set.Compile();
+                    }
+
+                    if (_haserrors) throw new BadSchemaException(_errors.ToString());
+
+                    set.Add(xs);
+                }
+            }
+
+            return true;
+        }
+
+        private bool IsStandaloneSchematron(string namespaceUri)
+        {
+            return namespaceUri == Schema.Namespace;
+        }
+
+        private bool IsStandardSchema(string namespaceUri)
+        {
+            return namespaceUri == XmlSchema.Namespace;
+        }
+        /// <summary>
+        /// Adds a schema to the collection to use for validation.
+        /// </summary>
+        /// <remarks>Validation takes place here.</remarks>
+        public void AddSchema(string targetNamespace, string schemaUri)
+        {
+            var xmlContent = default(string);
+            var nameTable = default(XmlNameTable);
+            var namespaceUri = default(string);
+
+            TryAddXmlSchema(targetNamespace, schemaUri, _xmlschemas, OnValidation, out xmlContent, out nameTable, out namespaceUri);
+
+            XmlDocument doc = new XmlDocument(nameTable);
+            doc.LoadXml(xmlContent);
+
+            XPathNavigator nav = doc.CreateNavigator();
+            _evaluationctx.Source = nav;
+
+            if (IsStandaloneSchematron(namespaceUri))
+                PerformValidation(Config.FullSchematron);
+            else
+                PerformValidation(Config.EmbeddedSchematron);
+
+            if (_evaluationctx.HasErrors)
+                throw new BadSchemaException(_evaluationctx.Messages.ToString());
+
+            Schema sch = new Schema();
+            sch.Load(nav);
+
+            _schematrons.Add(sch);
+            _errors = null;
+        }
+
+        #endregion
+
+
 		#endregion
 
 		#region Validation Methods


### PR DESCRIPTION
Added a new Validator.AddSchema() signature so the XmlSchemaSet can resolve imports instead of supplying a XmlReader that apparently can't follow hints from schemaLocation.
Will refactor a bit in a near future towards DRY.
Added a very rough test project just to make sure the new signature has the same output as the existing one (used test data from the previous NMatrix.Schematron WinForms test app. Tests SHOULD be improved soon.
