### PR TITLE
Speed-up determining the position of a node in the path.

### DIFF
--- a/src/Schematron/Formatters/FormattingUtils.cs
+++ b/src/Schematron/Formatters/FormattingUtils.cs
@@ -31,6 +31,8 @@ namespace Schematron.Formatters
 		{
 		}
 
+		private static XPathExpression precedingSiblingsExpr = XPathExpression.Compile("preceding-sibling::*");
+
 		/// <summary>
 		/// Returns the full path to the context node. Clone the navigator to avoid loosing positioning.
 		/// </summary>
@@ -75,9 +77,8 @@ namespace Schematron.Formatters
 			}
 
 			int sibs = 1;
-
-			while (context.MoveToPrevious())
-				if (context.Name == curr) sibs++;
+			foreach (XPathNavigator prev in context.Select(precedingSiblingsExpr))
+				if (prev.Name == curr) sibs++;
 
 			if (context.MoveToParent())
 			{

--- a/src/Schematron/SyncEvaluationContext.cs
+++ b/src/Schematron/SyncEvaluationContext.cs
@@ -147,7 +147,7 @@ namespace Schematron
 		/// different methods for accessing the underlying source. 
 		/// <para>
 		/// This makes the implementation both performant and compliant with
-		/// the restriction about node mathing (see <linkref id="schematron" />) in the spec.
+		/// the restriction about node matching (see <linkref id="schematron" />) in the spec.
 		/// </para>
 		/// <para>
 		///		<seealso cref="DomMatchedNodes"/>


### PR DESCRIPTION
When a node of a type that is tested by a schematron rule, has many (tens of thousands) preceding siblings (of the same type), determining the position among the siblings was slow. This made the computation of the `<path>` in the schematron report very slow.
The proposed change speeds up computing the `<path>` a lot. On one large file (~50000 items) the processing time went from 8 minutes to 10 seconds.
