### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,94 @@
+# .NET Repository
+
+**Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.**
+
+## Working Effectively
+
+### Essential Build Commands
+- **Restore dependencies**: `dotnet restore`
+
+- **Build the entire solution**: `dotnet build`
+
+- **Run tests**: `dnx --yes retest`
+  - Runs all unit tests across the solution
+  - If tests fail due to Azure Storage, run the following commands and retry: `npm install azurite` and `npx azurite &`
+
+### Build Validation and CI Requirements
+- **Always run before committing**: 
+  * `dnx --yes retest`
+  * `dotnet format whitespace -v:diag --exclude ~/.nuget`
+  * `dotnet format style -v:diag --exclude ~/.nuget`
+
+### Project Structure and Navigation
+
+| Directory | Description |
+|-----------|-------------|
+| `src/` | Contains the repo source code. |
+| `bin/` | Contains built packages (if any) |
+
+### Code Style and Formatting
+
+#### EditorConfig Rules
+The repository uses `.editorconfig` at the repo root for consistent code style.
+
+- **Indentation**: 4 spaces for C# files, 2 spaces for XML/YAML/JSON
+- **Line endings**: LF (Unix-style)
+- **Sort using directives**: System.* namespaces first (`dotnet_sort_system_directives_first = true`)
+- **Type references**: Prefer language keywords over framework type names (`int` vs `Int32`)
+- **Modern C# features**: Use object/collection initializers, coalesce expressions when possible, use var when the type is apparent from the right-hand side of the assignment
+- **Visibility modifiers**: only explicitly specify visibility when different from the default (e.g. `public` for classes, no `internal` for classes or `private` for fields, etc.)
+
+#### Formatting Validation
+- CI enforces formatting with `dotnet format whitespace` and `dotnet format style`
+- Run locally: `dotnet format whitespace --verify-no-changes -v:diag --exclude ~/.nuget`
+- Fix formatting: `dotnet format` (without `--verify-no-changes`)
+
+### Testing Practices
+
+#### Test Framework
+- **xUnit** for all unit and integration tests
+- **Moq** for mocking dependencies
+- Located in `src/*.Tests/`
+
+#### Test Attributes
+Custom xUnit attributes are sometimes used for conditional test execution:
+- `[SecretsFact("XAI_API_KEY")]` - Skips test if required secrets are missing from user secrets or environment variables
+- `[LocalFact("SECRET")]` - Runs only locally (skips in CI), requires specified secrets
+- `[CIFact]` - Runs only in CI environment
+
+### Dependency Management
+
+#### Adding Dependencies
+- Add to appropriate `.csproj` file
+- Run `dotnet restore` to update dependencies
+- Ensure version consistency across projects where applicable
+
+#### CI/CD Pipeline
+- **Build workflow**: `.github/workflows/build.yml` - runs on PR and push to main/rel/feature branches
+- **Publish workflow**: Publishes to Sleet feed when `SLEET_CONNECTION` secret is available
+- **OS matrix**: Configured in `.github/workflows/os-matrix.json` (defaults to ubuntu-latest)
+
+### Special Files and Tools
+
+#### dnx Command
+- **Purpose**: built-in tool for running arbitrary dotnet tools that are published on nuget.org. `--yes` auto-confirms install before run.
+- **Example**: `dnx --yes retest` - runs tests with automatic retry on transient failures (retest being a tool package published at https://www.nuget.org/packages/retest)
+- **In CI**: `dnx --yes retest -- --no-build` (skips build, runs tests only)
+
+#### Directory.Build.rsp
+- MSBuild response file with default build arguments
+- `-nr:false` - disables node reuse
+- `-m:1` - single-threaded build (for stability)
+- `-v:m` - minimal verbosity
+
+#### Code Quality
+- All PRs must pass format validation
+- Tests must pass on all target frameworks
+- Follow existing patterns and conventions in the codebase
+
+## Documenting Work
+
+Project implemention details, design and key decisions should be documented in a top-level AGENTS.md file at the repo root. 
+Keep this file updated whenever you make change significant changes for future reference.
+
+User-facing features and APIs should be documented to highlight (not extensively, as an overview) key project features and capabilities, in the readme.md file at the repo root.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
     Web:
       patterns:
         - "Microsoft.AspNetCore*"
+    OpenTelemetry:
+      patterns:
+        - "OpenTelemetry*"
     Tests:
       patterns:
         - "Microsoft.NET.Test*"

--- a/.github/workflows/dotnet-env.yml
+++ b/.github/workflows/dotnet-env.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   which-dotnet:
     runs-on: ubuntu-latest 
+    env:
+      PR_TOKEN: ${{ secrets.DEVLOOPED_TOKEN || secrets.GH_TOKEN }}
     permissions:
       contents: write
       pull-requests: write
@@ -20,18 +22,19 @@ jobs:
         with:
           name: ${{ secrets.BOT_NAME }}
           email: ${{ secrets.BOT_EMAIL }}
-          gh_token: ${{ secrets.GH_TOKEN }}
+          gh_token: ${{ env.PR_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🤘 checkout
         uses: actions/checkout@v4
         with: 
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.PR_TOKEN || github.token }}
 
       - name: 🤌 dotnet
         uses: devlooped/actions-which-dotnet@v1
 
       - name: ✍ pull request
+        if: env.PR_TOKEN != ''
         uses: peter-evans/create-pull-request@v7
         with:
           base: main
@@ -41,4 +44,9 @@ jobs:
           title: "⚙ Update dotnet versions"
           body: "Update dotnet versions"
           commit-message: "Update dotnet versions"
-          token: ${{ env.GH_TOKEN }}          
+          token: ${{ env.PR_TOKEN }}
+
+      - name: ⚠️ skip pull request
+        if: env.PR_TOKEN == ''
+        shell: bash
+        run: echo "::warning::Skipping PR creation because neither DEVLOOPED_TOKEN nor GH_TOKEN is configured. GITHUB_TOKEN cannot create pull requests in this repository."

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   includes:
     runs-on: ubuntu-latest
+    env:
+      PR_TOKEN: ${{ secrets.DEVLOOPED_TOKEN || secrets.GH_TOKEN }}
     permissions:
       contents: write
       pull-requests: write
@@ -21,13 +23,13 @@ jobs:
         with:
           name: ${{ secrets.BOT_NAME }}
           email: ${{ secrets.BOT_EMAIL }}
-          gh_token: ${{ secrets.GH_TOKEN }}
+          gh_token: ${{ env.PR_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🤘 checkout
         uses: actions/checkout@v4
         with: 
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.PR_TOKEN || github.token }}
 
       - name: +Mᐁ includes
         uses: devlooped/actions-includes@v1
@@ -50,6 +52,7 @@ jobs:
           ((get-content -raw $file) -replace '\$product\$',$product).trim() | set-content $file
 
       - name: ✍ pull request
+        if: env.PR_TOKEN != ''
         uses: peter-evans/create-pull-request@v8
         with:
           add-paths: |
@@ -64,4 +67,9 @@ jobs:
           commit-message: +Mᐁ includes
           title: +Mᐁ includes
           body: +Mᐁ includes
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.PR_TOKEN }}
+
+      - name: ⚠️ skip pull request
+        if: env.PR_TOKEN == ''
+        shell: bash
+        run: echo "::warning::Skipping PR creation because neither DEVLOOPED_TOKEN nor GH_TOKEN is configured. GITHUB_TOKEN cannot create pull requests in this repository."

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -49,7 +49,11 @@ jobs:
           # if we don't have at least 100 requests left, wait until reset
           if ($rate.remaining -lt 100) {
               $wait = ($rate.reset - (Get-Date (Get-Date).ToUniversalTime() -UFormat %s))
-              echo "Rate limit remaining is $($rate.remaining), waiting for $($wait / 1000) seconds to reset"
+              if ($wait -gt 300) {
+                  echo "Rate limit remaining is $($rate.remaining), reset in $wait seconds (more than 5'). Aborting."
+                  exit 1
+              }
+              echo "Rate limit remaining is $($rate.remaining), waiting $wait seconds to reset"
               sleep $wait
               $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
               echo "Rate limit has reset to $($rate.remaining) requests"

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,23 @@
 bin
 obj
+out
 artifacts
 pack
+agent-tools
+terminals
 TestResults
 results
 BenchmarkDotNet.Artifacts
+mcps
 /app
+/temp
 .vs
 .vscode
 .genaiscript
 .idea
 local.settings.json
 .env
+.next
 *.local
 
 *.suo
@@ -26,6 +32,7 @@ local.settings.json
 *.binlog
 *.zip
 __azurite*.*
+AzuriteConfig
 __*__
 
 .nuget

--- a/.netconfig
+++ b/.netconfig
@@ -30,8 +30,8 @@
 	weak
 [file ".github/dependabot.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/dependabot.yml
-	sha = e733294084fb3e75d517a2e961e87df8faae7dc6
-	etag = 3bf8d9214a15c049ca5cfe80d212a8cbe4753b8a638a9804ef73d34c7def9618
+	sha = 387f0616b2c56adc4f33f2858da818f7e0d92ef3
+	etag = a1aaba1440e5ee2a7b7f93fc0fb004d4e1d4d9780350c753f7c429e37241345a
 	weak
 [file ".github/release.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/release.yml
@@ -55,8 +55,8 @@
 	weak
 [file ".github/workflows/dotnet-env.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-env.yml
-	sha = 77e83f238196d2723640abef0c7b6f43994f9747
-	etag = fcb9759a96966df40dcd24906fd328ddec05953b7e747a6bb8d0d1e4c3865274
+	sha = 7c1c6e615b5785e0ac9db33cb17343d6c1de16ff
+	etag = 68c1e28f475ff9d05f985bf53a51fce6e64b24a8b75bd8e47119ff57309281f1
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
@@ -65,8 +65,8 @@
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 06628725a6303bb8c4cf3076a384fc982a91bc0b
-	etag = 478f91d4126230e57cc601382da1ba23f9daa054645b4af89800d8dd862e64fd
+	sha = 7c1c6e615b5785e0ac9db33cb17343d6c1de16ff
+	etag = 5e6a10be141ee629201bfad01eae09b5c36a67f541ec7ab411ae400b5d73de1d
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
@@ -75,13 +75,13 @@
 	weak
 [file ".github/workflows/triage.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/triage.yml
-	sha = 33000c0c4ab4eb4e0e142fa54515b811a189d55c
-	etag = 013a47739e348f06891f37c45164478cca149854e6cd5c5158e6f073f852b61a
+	sha = 61a602fc61eedbdae235f01e93657a6219ac2427
+	etag = 152cd3a559c08da14d1da12a5262ba1d2e0ed6bed6d2eabf5bd209b0c35d8a75
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = a225b7a9f609f26bcc24e0d84f663387be251a7d
-	etag = 20a8b49d57024abbd85aac5b0020c30e5eb68e0384b2761e93727c8780c4a991
+	sha = ff61659751374b95c7a8a0477c908a8119f756f0
+	etag = e5865f083db45081a7b4eaa518018971b34e6ef93f917ac510dea96d27f792b3
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -105,16 +105,27 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = 0ff8b7b79a82112678326d1dc5543ed890311366
-	etag = 3ebde0a8630d526b80f15801179116e17a857ff880a4442e7db7b075efa4fd63
+	sha = 6e2438919e108aeb75106dc0737c45f5e55d5f42
+	etag = f1d6384abf18d8d891ce5e835a10c73fe029c42151374be96d7e4af43d189c65
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 4339749ef4b8f66def75931df09ef99c149f8421
-	etag = 8b4492765755c030c4c351e058a92f53ab493cab440c1c0ef431f6635c4dae0e
+	sha = c67952501337303eda0fb8b340cb7606666abd8f
+	etag = cb83faed0cc8b930a7b6bdc61bea03a54059858cf04353e55fee94d9e3ae0fad
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
 	sha = 032439dbf180fca0539a5bd3a019f18ab3484b76
 	etag = da7c0104131bd474b52fc9bc9f9bda6470e24ae38d4fb9f5c4f719bc01370ab5
+	weak
+[file "readme.tmp.md"]
+	url = https://github.com/devlooped/oss/blob/main/readme.tmp.md
+	skip
+[file "oss.cs"]
+	url = https://github.com/devlooped/oss/blob/main/oss.cs
+	skip
+[file ".github/copilot-instructions.md"]
+	url = https://github.com/devlooped/oss/blob/main/.github/copilot-instructions.md
+	sha = e616d89d9537c4b8ccf1c20dd277ab82104167c4
+	etag = 6ee650d118a57494d3545d54718ccaa5257b09d54504e9c21514fe596edd9678
 	weak

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,6 @@ The package currently supports the main scenarios expected for a v1 release, inc
 <!-- sponsors.md -->
 [![Clarius Org](https://avatars.githubusercontent.com/u/71888636?v=4&s=39 "Clarius Org")](https://github.com/clarius)
 [![MFB Technologies, Inc.](https://avatars.githubusercontent.com/u/87181630?v=4&s=39 "MFB Technologies, Inc.")](https://github.com/MFB-Technologies-Inc)
-[![Khamza Davletov](https://avatars.githubusercontent.com/u/13615108?u=11b0038e255cdf9d1940fbb9ae9d1d57115697ab&v=4&s=39 "Khamza Davletov")](https://github.com/khamza85)
 [![SandRock](https://avatars.githubusercontent.com/u/321868?u=99e50a714276c43ae820632f1da88cb71632ec97&v=4&s=39 "SandRock")](https://github.com/sandrock)
 [![DRIVE.NET, Inc.](https://avatars.githubusercontent.com/u/15047123?v=4&s=39 "DRIVE.NET, Inc.")](https://github.com/drivenet)
 [![Keith Pickford](https://avatars.githubusercontent.com/u/16598898?u=64416b80caf7092a885f60bb31612270bffc9598&v=4&s=39 "Keith Pickford")](https://github.com/Keflon)
@@ -195,10 +194,11 @@ The package currently supports the main scenarios expected for a v1 release, inc
 [![domischell](https://avatars.githubusercontent.com/u/66068846?u=0a5c5e2e7d90f15ea657bc660f175605935c5bea&v=4&s=39 "domischell")](https://github.com/DominicSchell)
 [![Adrian Alonso](https://avatars.githubusercontent.com/u/2027083?u=129cf516d99f5cb2fd0f4a0787a069f3446b7522&v=4&s=39 "Adrian Alonso")](https://github.com/adalon)
 [![torutek](https://avatars.githubusercontent.com/u/33917059?v=4&s=39 "torutek")](https://github.com/torutek)
-[![mccaffers](https://avatars.githubusercontent.com/u/16667079?u=110034edf51097a5ee82cb6a94ae5483568e3469&v=4&s=39 "mccaffers")](https://github.com/mccaffers)
+[![Ryan McCaffery](https://avatars.githubusercontent.com/u/16667079?u=c0daa64bb5c1b572130e05ae2b6f609ecc912d4d&v=4&s=39 "Ryan McCaffery")](https://github.com/mccaffers)
 [![Seika Logiciel](https://avatars.githubusercontent.com/u/2564602?v=4&s=39 "Seika Logiciel")](https://github.com/SeikaLogiciel)
 [![Andrew Grant](https://avatars.githubusercontent.com/devlooped-user?s=39 "Andrew Grant")](https://github.com/wizardness)
 [![eska-gmbh](https://avatars.githubusercontent.com/devlooped-team?s=39 "eska-gmbh")](https://github.com/eska-gmbh)
+[![Geodata AS](https://avatars.githubusercontent.com/u/5946299?v=4&s=39 "Geodata AS")](https://github.com/geodata-no)
 
 
 <!-- sponsors.md -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -47,6 +47,9 @@
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <!-- See https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#prunepackagereference-specification -->
     <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
+
+    <!-- Needed to improve nuget default for empty PackageId. Workaround for https://github.com/NuGet/Home/issues/14928 -->
+    <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -164,6 +167,10 @@
     <Using Include="System.ArgumentException" Static="true" />
     <Using Include="System.ArgumentOutOfRangeException" Static="true" />
     <Using Include="System.ArgumentNullException" Static="true" />
+  </ItemGroup>
+
+  <ItemGroup Label="OSMF" Condition="Exists('$(MSBuildThisFileDirectory)..\osmfeula.txt')">
+    <Content Include="$(MSBuildThisFileDirectory)..\osmfeula.txt" Link="osmfeula.txt" Pack="true" PackagePath="OSMFEULA.txt" Visible="false" />
   </ItemGroup>
 
   <Import Project="Directory.props" Condition="Exists('Directory.props')"/>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -32,6 +32,22 @@
     <IsPackable Condition="'$(PackageId)' != ''">true</IsPackable>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <!-- Save original PackageId to restore post-import -->
+    <_PackageId>$(PackageId)</_PackageId>
+    <!-- Since we set ImportNuGetBuildTasksPackTargetsFromSdk=false, the Sdk.targets doesn't even provide the path for this property :/ -->
+    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == ''">$(MSBuildSDKsPath)\..\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)')"/>
+
+  <PropertyGroup>
+    <!-- Revert the forced PackageId by the NuGet SDK targets for non-packable projects, see https://github.com/NuGet/Home/issues/14928 -->
+    <PackageId Condition="'$(IsPackable)' == 'false'">$(_PackageId)</PackageId>
+    <!-- If no PackageId was originally provided, ensure IsPackable is false -->
+    <IsPackable Condition="'$(_PackageId)' == ''">false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsPackable)' == 'true'" Label="NuGet">
     <!-- This is compatible with nugetizer and SDK pack -->
     <!-- Only difference is we don't copy either to output directory -->
@@ -174,7 +190,7 @@
 
   <Target Name="UpdatePackageMetadata"
           BeforeTargets="PrepareForBuild;GenerateMSBuildEditorConfigFileShouldRun;GetAssemblyVersion;GetPackageMetadata;GenerateNuspec;Pack"
-          DependsOnTargets="EnsureProjectInformation"
+          DependsOnTargets="EnsureProjectInformation;UpdatePackageLicense"
           Condition="'$(SourceControlInformationFeatureSupported)' == 'true' And
                      '$(IsPackable)' == 'true'">
     <PropertyGroup>
@@ -183,6 +199,16 @@
       <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl.Replace('.git', ''))/blob/main/changelog.md</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
+
+  <Target Name="UpdatePackageLicense">
+    <!-- If project has a None/Content item with PackagePath=OSMFEULA.txt -->
+    <PropertyGroup Condition="@(None -> WithMetadataValue('PackagePath', 'OSMFEULA.txt')) != '' or @(Content -> WithMetadataValue('PackagePath', 'OSMFEULA.txt')) != ''">
+      <PackageLicenseExpression></PackageLicenseExpression>
+      <PackageLicenseFile>OSMFEULA.txt</PackageLicenseFile>
+      <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    </PropertyGroup>
+  </Target>
+
 
   <!-- Import before UsingTask because first to declare tasks wins -->
   <Import Project="Directory.targets" Condition="Exists('Directory.targets')"/>


### PR DESCRIPTION
# devlooped/oss

- Enhance documentation instructions for project work https://github.com/devlooped/oss/commit/e616d89
- If the OSMF eula is present, switch to its license file https://github.com/devlooped/oss/commit/4b84c54
- Change file type from None to Content for osmfeula.txt https://github.com/devlooped/oss/commit/fd03672
- Add Pack attribute to OSMFEULA content item https://github.com/devlooped/oss/commit/dd13ed3
- Hide osmfeula.txt from package visibility https://github.com/devlooped/oss/commit/a1f5d11
- Fix PackageId default from Pack SDK https://github.com/devlooped/oss/commit/6e24389
- Refactor GitHub Actions workflows to use unified PR_TOKEN for authentication and add skip PR creation warning https://github.com/devlooped/oss/commit/7c1c6e6
- Add OpenTelemetry patterns to dependabot config https://github.com/devlooped/oss/commit/387f061
- Consider either None or Content for OSMF license patching https://github.com/devlooped/oss/commit/083a37b
- Cap rate limit wait at 5 minutes, abort if longer https://github.com/devlooped/oss/commit/61a602f
- Improve PackageId/IsPackable defaulting https://github.com/devlooped/oss/commit/e8b0802
- Fix empty default path for NuGet SDK targets https://github.com/devlooped/oss/commit/c679525
- Add AzuriteConfig to .gitignore https://github.com/devlooped/oss/commit/12c18e7
- Add new entries to .gitignore file https://github.com/devlooped/oss/commit/c76f0cc
- Add '/mcps' to .gitignore https://github.com/devlooped/oss/commit/c1d29fb
- Add '/temp' directory to .gitignore https://github.com/devlooped/oss/commit/79631d3
- Update .gitignore to ignore 'mcps' folder recursively https://github.com/devlooped/oss/commit/11680ae
- Add 'terminals' to .gitignore https://github.com/devlooped/oss/commit/5e7a79e
- Add 'agent-tools' to .gitignore https://github.com/devlooped/oss/commit/ff61659